### PR TITLE
Fix deprecations in numpy and PIL

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/dicomslide/matrix.py
+++ b/src/dicomslide/matrix.py
@@ -398,7 +398,7 @@ class TotalPixelMatrix:
     @property
     def num_tiles(self) -> int:
         """int: Number of tiles"""
-        return int(np.product(self.tile_grid_shape))
+        return int(np.prod(self.tile_grid_shape))
 
     @property
     def tile_grid_shape(self) -> Tuple[int, int]:
@@ -411,7 +411,7 @@ class TotalPixelMatrix:
     @property
     def tile_size(self) -> int:
         """int: Size of an invidual tile (rows x columns x samples)"""
-        return int(np.product(self.tile_shape))
+        return int(np.prod(self.tile_shape))
 
     @property
     def tile_shape(self) -> Tuple[int, int, int]:
@@ -504,7 +504,7 @@ class TotalPixelMatrix:
     @property
     def size(self) -> int:
         """int: Size (rows x columns x samples)"""
-        return int(np.product(self.shape))
+        return int(np.prod(self.shape))
 
     @property
     def shape(self) -> Tuple[int, int, int]:

--- a/src/dicomslide/openslide.py
+++ b/src/dicomslide/openslide.py
@@ -279,7 +279,14 @@ class OpenSlide:
         )
         thumb = PillowImage.new('RGB', tile.size, background_color)
         thumb.paste(tile, None, tile)
-        thumb.thumbnail(size, PillowImage.ANTIALIAS)
+        try:
+            resamping_method = PillowImage.Resampling.LANCZOS
+        except AttributeError:
+            # May be using a version of Pillow before 10.0.0, especially if
+            # using an older version of Python
+            resamping_method = PillowImage.ANTIALIAS
+
+        thumb.thumbnail(size, resamping_method)
         return thumb
 
     def __enter__(self):

--- a/src/dicomslide/openslide.py
+++ b/src/dicomslide/openslide.py
@@ -280,7 +280,7 @@ class OpenSlide:
         thumb = PillowImage.new('RGB', tile.size, background_color)
         thumb.paste(tile, None, tile)
         try:
-            resamping_method = PillowImage.Resampling.LANCZOS
+            resamping_method = PillowImage.Resampling.LANCZOS  # type: ignore
         except AttributeError:
             # May be using a version of Pillow before 10.0.0, especially if
             # using an older version of Python


### PR DESCRIPTION
Workaround two deprecations in dependencies:

- Numpy deprecated `np.product` in favour of `np.prod`
- PIL deprecated `PIL.Image.ANTIALIAS` in favour of `PIL.Image.Resampling.LANCZOS`